### PR TITLE
New toasts get pushed to ToastShelf via state

### DIFF
--- a/src/components/Toast/Toast.js
+++ b/src/components/Toast/Toast.js
@@ -18,7 +18,7 @@ const ICONS_BY_VARIANT = {
   error: AlertOctagon,
 };
 
-function Toast({ handleDismiss, variant, children }) {
+function Toast({ id, handleDismiss, variant, children }) {
   const Icon = ICONS_BY_VARIANT[variant];
 
   return (
@@ -27,7 +27,12 @@ function Toast({ handleDismiss, variant, children }) {
         <Icon size={24} />
       </div>
       <p className={styles.content}>{children}</p>
-      <button className={styles.closeButton} onClick={handleDismiss}>
+      <button
+        className={styles.closeButton}
+        onClick={() => {
+          handleDismiss(id);
+        }}
+      >
         <X size={24} />
         <VisuallyHidden>Dismiss message</VisuallyHidden>
       </button>

--- a/src/components/ToastPlayground/ToastPlayground.js
+++ b/src/components/ToastPlayground/ToastPlayground.js
@@ -1,19 +1,41 @@
 import React from "react";
 
 import Button from "../Button";
-import Toast from "../Toast";
+import ToastShelf from "../ToastShelf";
 
 import styles from "./ToastPlayground.module.css";
 
 const VARIANT_OPTIONS = ["notice", "warning", "success", "error"];
 
 function ToastPlayground() {
-  const [isRendered, setIsRendered] = React.useState(false);
   const [message, setMessage] = React.useState("");
   const [variant, setVariant] = React.useState(VARIANT_OPTIONS[0]);
+  const [toasts, setToasts] = React.useState([]);
 
-  function handleDismiss() {
-    setIsRendered(false);
+  function handleCreateToast(event) {
+    event.preventDefault();
+
+    const nextToasts = [
+      ...toasts,
+      {
+        id: crypto.randomUUID(),
+        message,
+        variant,
+      },
+    ];
+
+    setToasts(nextToasts);
+
+    setMessage("");
+    setVariant(VARIANT_OPTIONS[0]);
+  }
+
+  function handleDismiss(id) {
+    const nextToasts = toasts.filter((toast) => {
+      return toast.id !== id;
+    });
+
+    setToasts(nextToasts);
   }
 
   return (
@@ -22,70 +44,61 @@ function ToastPlayground() {
         <img alt="Cute toast mascot" src="/toast.png" />
         <h1>Toast Playground</h1>
       </header>
-
-      {isRendered && (
-        <Toast variant={variant} handleDismiss={handleDismiss}>
-          {message}
-        </Toast>
-      )}
-      <div className={styles.controlsWrapper}>
-        <div className={styles.row}>
-          <label
-            htmlFor="message"
-            className={styles.label}
-            style={{ alignSelf: "baseline" }}
-          >
-            Message
-          </label>
-          <div className={styles.inputWrapper}>
-            <textarea
-              id="message"
-              className={styles.messageInput}
-              onChange={(event) => {
-                setMessage(event.target.value);
-              }}
-              value={message}
-            ></textarea>
-          </div>
-        </div>
-
-        <div className={styles.row}>
-          <div className={styles.label}>Variant</div>
-          <div className={`${styles.inputWrapper} ${styles.radioWrapper}`}>
-            {VARIANT_OPTIONS.map((option) => {
-              const id = `variant-${option}`;
-              return (
-                <label key={id} htmlFor={`variant-${option}`}>
-                  <input
-                    id={`variant-${option}`}
-                    type="radio"
-                    name="variant"
-                    value={option}
-                    checked={option === variant}
-                    onChange={(event) => {
-                      setVariant(event.target.value);
-                    }}
-                  />
-                  {option}
-                </label>
-              );
-            })}
-          </div>
-        </div>
-
-        <div className={styles.row}>
-          <div className={styles.label} />
-          <div className={`${styles.inputWrapper} ${styles.radioWrapper}`}>
-            <Button
-              onClick={() => {
-                setIsRendered(true);
-              }}
+      <ToastShelf handleDismiss={handleDismiss} toasts={toasts} />
+      <form onSubmit={handleCreateToast}>
+        <div className={styles.controlsWrapper}>
+          <div className={styles.row}>
+            <label
+              htmlFor="message"
+              className={styles.label}
+              style={{ alignSelf: "baseline" }}
             >
-              Pop Toast!
-            </Button>
+              Message
+            </label>
+            <div className={styles.inputWrapper}>
+              <textarea
+                id="message"
+                className={styles.messageInput}
+                onChange={(event) => {
+                  setMessage(event.target.value);
+                }}
+                value={message}
+              ></textarea>
+            </div>
+          </div>
+
+          <div className={styles.row}>
+            <div className={styles.label}>Variant</div>
+            <div className={`${styles.inputWrapper} ${styles.radioWrapper}`}>
+              {VARIANT_OPTIONS.map((option) => {
+                const id = `variant-${option}`;
+                return (
+                  <label key={id} htmlFor={`variant-${option}`}>
+                    <input
+                      id={`variant-${option}`}
+                      type="radio"
+                      name="variant"
+                      value={option}
+                      checked={option === variant}
+                      onChange={(event) => {
+                        setVariant(event.target.value);
+                      }}
+                    />
+                    {option}
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className={styles.row}>
+            <div className={styles.label} />
+            <div className={`${styles.inputWrapper} ${styles.radioWrapper}`}>
+              <Button>Pop Toast!</Button>
+            </div>
           </div>
         </div>
-      </div>
+      </form>
     </div>
   );
 }

--- a/src/components/ToastShelf/ToastShelf.js
+++ b/src/components/ToastShelf/ToastShelf.js
@@ -1,17 +1,22 @@
-import React from 'react';
+import React from "react";
 
-import Toast from '../Toast';
-import styles from './ToastShelf.module.css';
+import Toast from "../Toast";
+import styles from "./ToastShelf.module.css";
 
-function ToastShelf() {
+function ToastShelf({ toasts, handleDismiss }) {
   return (
     <ol className={styles.wrapper}>
-      <li className={styles.toastWrapper}>
-        <Toast variant="notice">Example notice toast</Toast>
-      </li>
-      <li className={styles.toastWrapper}>
-        <Toast variant="error">Example error toast</Toast>
-      </li>
+      {toasts.map((toast) => (
+        <li key={toast.id} className={styles.toastWrapper}>
+          <Toast
+            id={toast.id}
+            variant={toast.variant}
+            handleDismiss={handleDismiss}
+          >
+            {toast.message}
+          </Toast>
+        </li>
+      ))}
     </ol>
   );
 }


### PR DESCRIPTION
- The playground pushes new toast messages onto a stack, rendered inside ToastShelf which is shown in the corner of the page.
- When “Pop Toast!” is clicked, the message/variant form controls are reset to their default state (message is an empty string, variant is "notice").
- Clicking the “×” button inside the toast removes that specific toast (but leaves the rest untouched).
- A proper <form> tag is used in the ToastPlayground. The toast is created when submitting the form.
- There are no key warnings in the console